### PR TITLE
Add compat entries suggested by CompatHelper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,9 +17,13 @@ TextAnalysis = "a2db99b7-8b79-58f8-94bf-bbc811eef33d"
 WordTokenizers = "796a5d58-b03d-544a-977e-18100b691f6e"
 
 [compat]
+Chain = "0.6"
+DataFrames = "1"
 DataStructures = "0.18"
 Distances = "0.10"
 FreqTables = "0.4"
+Memoize = "0.4"
+StatsBase = "0.34"
 TextAnalysis = "0.8"
 WordTokenizers = "0.5"
 julia = "1.10"


### PR DESCRIPTION
Added:
  - StatsBase@0.34 (closes #27)
  - Memoize@0.4 (closes #28)
  - DataFrames@1 (closes #29)
  - Chain@0.6 (closes #30)

Now, all dependencies (except for LinearAlgebra and Sparse arrays, which are both standard libraries) have compat entries, as required.